### PR TITLE
Make the automated session config window narrower

### DIFF
--- a/views/cfgautomated.ejs
+++ b/views/cfgautomated.ejs
@@ -22,7 +22,7 @@
   <button onclick="toggleTheme()" id="theme-toggler">Toggle Theme</button>
   <h1 class="electron-title"><a href="/">electron</a></h1>
 
-  <div id="main-container">
+  <div id="main-container" style="width:450px;">
     <div id="left-channel-column" style="margin:0;width:100%">
       <div class="color-header">
         <h2>Config Automated Session</h2>


### PR DESCRIPTION
There's currently a lot of dead space in the automated config window due to it having the same width as the main player window but only being a single column wide. I set the width to 450px and I personally think it looks much nicer. It's definitely a subjective change though.

![image](https://github.com/fallenangel42/electron/assets/67182075/a667c02a-ef09-4167-82ac-20cbcc4a8dac)